### PR TITLE
Add query

### DIFF
--- a/test/test_url.py
+++ b/test/test_url.py
@@ -105,9 +105,9 @@ class UrlTest(unittest.TestCase):
         self.assertIn('field4', ext_url.form)
 
         ## if initial query exists, it should include the both fields
-        query2 = {'field3': 'value3', 'field4': [1, 2, 3]}
+        ext_query = {'field3': 'value3', 'field4': [1, 2, 3]}
         ext_url = url.add_query({'field3': 'value3', 'field4': [1, 2, 3]})
-        self.assertEqual(ext_url.query, '%s&%s'%(query, ext_query))
+        self.assertEqual(ext_url.query, '%s&%s'%(query, 'field3=value3&field4=1&field4=2&field4=3'))
         self.assertSetEqual(set(ext_url.form), {'field1', 'field2', 'field3', 'field4'})
         self.assertIn('field1', ext_url.form)
         self.assertIn('field2', ext_url.form)

--- a/test/test_url.py
+++ b/test/test_url.py
@@ -90,6 +90,37 @@ class UrlTest(unittest.TestCase):
         self.assertTupleEqual(url.form.get('field3'), ('value3', ))
         self.assertTupleEqual(url.form.get('field4'), ('1', '2', '3'))
 
+    def test_add_query(self):
+        query = 'field1=value1&field1=value2&field2=hello,%20world%26python'
+        url = URL('http://www.example.com/form?' + query)
+
+        ## if initial query is null, it should include the added query
+        ext_url = url.with_query('').add_query({'field3': 'value3', 'field4': [1, 2, 3]}) 
+        self.assertSetEqual(set(ext_url.form), {'field3', 'field4'})
+        self.assertTupleEqual(ext_url.form.get('field3'), ('value3', ))
+        self.assertTupleEqual(ext_url.form.get('field4'), ('1', '2', '3'))
+        self.assertNotIn('field1', ext_url.form)
+        self.assertNotIn('field2', ext_url.form)
+        self.assertIn('field3', ext_url.form)
+        self.assertIn('field4', ext_url.form)
+
+        ## if initial query exists, it should include the both fields
+        query2 = {'field3': 'value3', 'field4': [1, 2, 3]}
+        ext_url = url.add_query({'field3': 'value3', 'field4': [1, 2, 3]})
+        self.assertEqual(ext_url.query, '%s&%s'%(query, ext_query))
+        self.assertSetEqual(set(ext_url.form), {'field1', 'field2', 'field3', 'field4'})
+        self.assertIn('field1', ext_url.form)
+        self.assertIn('field2', ext_url.form)
+        self.assertIn('field3', ext_url.form)
+        self.assertIn('field4', ext_url.form)
+        self.assertTupleEqual(ext_url.form.get('field1'), ('value1', 'value2'))
+        self.assertTupleEqual(ext_url.form.get('field2'), ('hello, world&python', ))
+        self.assertTupleEqual(ext_url.form.get('field3'), ('value3', ))
+        self.assertTupleEqual(ext_url.form.get('field4'), ('1', '2', '3'))
+
+        ## if added query is null, it should include original query
+        self.assertEqual(url.add_query({}).query, query)
+
     def test_query_field_order(self):
         url = URL('http://example.com/').with_query(field1='field1', field2='field2', field3='field3')
 

--- a/urlpath.py
+++ b/urlpath.py
@@ -444,6 +444,27 @@ class URL(urllib.parse._NetlocResultMixinStr, PurePath):
         """Return a new url with the fragment changed."""
         return self.with_components(fragment=fragment)
 
+    def add_query(self, query=None, **kwargs):
+        """Return a new url with the query ammended."""
+        assert not (query and kwargs)
+        query = query or kwargs
+        if not query:
+            return self.with_components()
+        current = self.query
+        if not current:
+            return self.with_components(query=query)
+        appendix = ''     # suppress lint warnings
+        if isinstance(query, collections.Mapping):
+            appendix = urllib.parse.urlencode(sorted(query.items()), **self._urlencode_args)
+        elif isinstance(query, collections.Sequence):
+            appendix = urllib.parse.urlencode(query, **self._urlencode_args)
+        elif query is not None:
+            appendix = str(query)
+        if appendix:
+            new = r'%s&%s' % (current, appendix) 
+            return self.with_components(new)
+        return self.with_components()
+
     def resolve(self):
         """Resolve relative path of the path.
         """

--- a/urlpath.py
+++ b/urlpath.py
@@ -440,10 +440,6 @@ class URL(urllib.parse._NetlocResultMixinStr, PurePath):
         assert not (query and kwargs)
         return self.with_components(query=query or kwargs)
 
-    def with_fragment(self, fragment):
-        """Return a new url with the fragment changed."""
-        return self.with_components(fragment=fragment)
-
     def add_query(self, query=None, **kwargs):
         """Return a new url with the query ammended."""
         assert not (query and kwargs)
@@ -461,9 +457,13 @@ class URL(urllib.parse._NetlocResultMixinStr, PurePath):
         elif query is not None:
             appendix = str(query)
         if appendix:
-            new = r'%s&%s' % (current, appendix) 
-            return self.with_components(new)
+            new = '%s&%s' % (current, appendix)
+            return self.with_components(query=new)
         return self.with_components()
+
+    def with_fragment(self, fragment):
+        """Return a new url with the fragment changed."""
+        return self.with_components(fragment=fragment)
 
     def resolve(self):
         """Resolve relative path of the path.


### PR DESCRIPTION
This PR adds an 'add_query' method which enables iterative build-up of urls.
`url.with_query(field1=x, field2=y) == url.with_query(field1=x).add_query(field2=y)`